### PR TITLE
Add release branches trigger to charts workflow

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-
+      - release-**
 jobs:
   release:
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions


### PR DESCRIPTION
This workflow will let us track major releases and trigger the workflow for them (eg.  release-1.16 branch to track v1.16.0, v1.16.1, ...)