### PR TITLE
Configure router deployment replicas

### DIFF
--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     application: fission-router
 spec:
 {{- if not .Values.router.deployAsDaemonSet }}
-  replicas: 1
+  replicas: {{ .Values.router.replicas | default 1 }}
 {{- end }}
   selector:
     matchLabels:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -172,6 +172,9 @@ router:
   ## deployAsDaemonSet decides whether to deploy router as a DaemonSet or a Deployment.
   ##
   deployAsDaemonSet: false
+  ## replicas decides how many router pods to deploy. Only used when deployAsDaemonSet is false.
+  ##
+  replicas: 1
   ## svcAddressMaxRetries is the max times for router to retry with a specific function service address
   ##
   svcAddressMaxRetries: 5


### PR DESCRIPTION
When deploying the router with `deployAsDaemonSet: false`, it would be useful to be able to specify how many router replicas would be deployed.