### PR TITLE
fix: add missing imagePullSecrets sections to pods

### DIFF
--- a/charts/fission-all/templates/analytics/nonhelm-install-job.yaml
+++ b/charts/fission-all/templates/analytics/nonhelm-install-job.yaml
@@ -37,4 +37,8 @@ spec:
           env:
             - name: GA_TRACKING_ID
               value: "{{ .Values.gaTrackingID }}"
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/fission-all/templates/analytics/post-install-job.yaml
+++ b/charts/fission-all/templates/analytics/post-install-job.yaml
@@ -47,4 +47,8 @@ spec:
         {{- if .Values.terminationMessagePolicy }}
           terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
         {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/fission-all/templates/analytics/post-upgrade-job.yaml
+++ b/charts/fission-all/templates/analytics/post-upgrade-job.yaml
@@ -47,4 +47,8 @@ spec:
           {{- if .Values.terminationMessagePolicy }}
           terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
           {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/fission-all/templates/fluentbit/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit/fluentbit.yaml
@@ -95,6 +95,10 @@ spec:
       labels:
         svc: logger
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       initContainers:
         - name: init
           image: {{ .Values.busyboxImage | quote }}

--- a/charts/fission-all/templates/influxdb/deployment.yaml
+++ b/charts/fission-all/templates/influxdb/deployment.yaml
@@ -49,6 +49,10 @@ spec:
             secretKeyRef:
               name: influxdb
               key: password
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
 {{- end }}

--- a/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
@@ -44,4 +44,8 @@ spec:
         terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
         {{- end }}
       serviceAccountName: fission-preupgrade
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
Some pods do not use the image pull secrets defined in the values. This adds the required section to make use of the image pull secrets to the respective pods.