### PR TITLE
Updated the chart to give fission-router access to create ingress in release namespace

### DIFF
--- a/charts/fission-all/templates/_fission-kubernetes-roles.tpl
+++ b/charts/fission-all/templates/_fission-kubernetes-roles.tpl
@@ -354,6 +354,8 @@ rules:
 # TODO: Kept for future in case preupgrade needs any permissions in the future
 rules: []
 {{- end }}
+# TODO: Currently, router needs ingress related permissions only.
+# In future if router's permissions are modified then check the configured namespace.
 {{- define "router-kuberules" }}
 rules:
 - apiGroups:

--- a/charts/fission-all/templates/router/role-kubernetes.yaml
+++ b/charts/fission-all/templates/router/role-kubernetes.yaml
@@ -1,4 +1,4 @@
-{{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "router") .) }}
+{{- include "kubernetes-role-generator" (merge (dict "namespace" .Release.Namespace "component" "router") .) }}
 
 {{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}


### PR DESCRIPTION
- fission-router has access to create ingress in default namespace.
- fission-router is creating ingress in namespace where fission is installed (release namespace) i.e., where router service is running.
- updated the fission-router access to create ingress in release namespace instead of default namespace.