### PR TITLE
Add Values.router.svcLabels feature

### DIFF
--- a/charts/fission-all/templates/router/svc.yaml
+++ b/charts/fission-all/templates/router/svc.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     svc: router
     application: fission-router
+    {{- if .Values.router.svcLabels }}
+    {{- toYaml .Values.router.svcLabels | nindent 4 }}
+    {{- end }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 {{- if .Values.router.svcAnnotations }}
   annotations:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -339,6 +339,10 @@ router:
   ## router resource utilization when under heavy workloads.
   ##
   displayAccessLog: false
+  ## svcLabels is the labels to be added to the service resource created for router.
+  ##
+  # svcLabels:
+  #   cloud.google.com/load-balancer-type: Internal
   ## svcAnnotations is the annotations to be added to the service resource created for router.
   ##
   # svcAnnotations:


### PR DESCRIPTION
Some CNI providers like CIlium use labels and not annotations to match against for applying a LoadBalancer IP. This pr adds in the ability to add custom labels to the router LoadBalancer service .